### PR TITLE
Improve offline reproducibility and evaluation diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Dataset archives (keep out of git; use external link or script)
+data_preprocess/data/*.zip
+
+# Unpacked datasets (large)
+data_preprocess/data/spider/
+data_preprocess/data/wikisql/
+data_preprocess/data/bird/
+
+# Generated example datasets (created by scripts/generate_data.sh)
+data_preprocess/data/example_text2sql_*.json
+
+# Training/eval outputs
+output/
+outputs/
+
+# Local/offline caches
+.hf_cache/
+cache/
+
+# Local models (optional)
+local_models/
+
+# Python caches
+__pycache__/
+*.pyc
+
+# Packaging artifacts
+sql_rl_gen.egg-info/
+
+# Editor/IDE metadata
+.vscode/
+.specstory/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ pip install -e .
 ``sql-rl-gen.egg-info`` compiled directory should appear
 ### 2. Data:
 1. Download data from: https://ibm.box.com/v/sql-rl-gen-data
-2. Unzip in ``./data_preprocess/data``. The files should be organised this way:
+2. Unzip in ``./data_preprocess/data``. (Dataset archives are not included in this repository.)
+   If you have a `spider.zip`, you can also extract it via:
+   ```shell
+   python scripts/setup_spider_data.py --zip-path data_preprocess/data/spider.zip
+   ```
+   The files should be organised this way:
 ```
 sql-rl-gen
 |     configs
@@ -81,7 +86,12 @@ It depends on what is created in a previous point. You might need to change the 
 chmod +rwx ./scripts/evaluate_model.sh
 ./scripts/evaluate_model.sh spider
 ```
-After the evaluation is finished, it will put files: ``feedback_metrics.csv`` and ``statistics_metrics.csv`` inside the ``./output./{model_name}``
+After the evaluation is finished, it will write ``feedback_metrics`` and ``statistics_metrics`` inside ``./output/{model_name}``.
+
+Optional: compare base vs RL checkpoints and generate a Markdown report:
+```shell
+python scripts/run_compare_eval.py --help
+```
 ## Technical reference
 
 **Memory**: 32 GB

--- a/configs/config.py
+++ b/configs/config.py
@@ -1,15 +1,19 @@
 import os
 
-ROOT_PATH = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-DATA_PATH = os.path.join(ROOT_PATH, "sql-rl-gen/data_preprocess/data")
+# Resolve project root (repo root) as the parent of this configs/ directory.
+# This makes paths robust to the clone directory name and working directory.
+ROOT_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# In-repo data directory
+DATA_PATH = os.path.join(ROOT_PATH, "data_preprocess", "data")
 SPIDER_PATH = os.path.join(DATA_PATH, "spider")
 SPIDER_DATABASES_PATH = os.path.join(SPIDER_PATH, "database")
 BIRD_PATH = os.path.join(DATA_PATH, "bird")
 BIRD_DATABASES_TRAIN_PATH = os.path.join(BIRD_PATH, "train", "train_databases")
 BIRD_DATABASES_DEV_PATH = os.path.join(BIRD_PATH, "dev", "dev_databases")
-WIKISQL_PATH = os.path.join(DATA_PATH, "wikiSQL")
+WIKISQL_PATH = os.path.join(DATA_PATH, "wikisql")
 EXT2TYPE = {"csv": "csv", "json": "json", "jsonl": "json", "txt": "text"}
-OUT_DIR = os.path.join(ROOT_PATH, "sql-rl-gen/output/")
+OUT_DIR = os.path.join(ROOT_PATH, "output")
 OUT_STATISTICS_DIR = os.path.join(OUT_DIR, "statistics")
 SQL_DATA_INFO = [
     {

--- a/configs/data_args.py
+++ b/configs/data_args.py
@@ -50,7 +50,7 @@ class DataArguments:
         },
     )
     dataset_dir: Optional[str] = field(
-        default=f"{ROOT_PATH}/sql-rl-gen/data_preprocess/data/",
+        default=f"{ROOT_PATH}/data_preprocess/data/",
         metadata={"help": "The name of the folder containing datasets."},
     )
     cutoff_len: Optional[int] = field(

--- a/data_preprocess/data_utils.py
+++ b/data_preprocess/data_utils.py
@@ -4,7 +4,7 @@ import os
 import sys
 from typing import Union, List, Optional
 from datasets import Dataset, IterableDataset, load_dataset, concatenate_datasets, interleave_datasets
-from configs.config import EXT2TYPE
+from configs.config import EXT2TYPE, ROOT_PATH
 from configs.data_args import DataArguments
 
 logging.basicConfig(level=logging.INFO, stream=sys.stdout, format='')
@@ -25,6 +25,12 @@ def checksum(data_files: List[str], file_sha1: Optional[str] = None) -> None:
 def get_dataset(data_args: "DataArguments") -> Union["Dataset", "IterableDataset"]:
     max_samples = data_args.max_samples
     all_datasets: List[Union["Dataset", "IterableDataset"]] = []  # support multiple datasets
+    # Keep HuggingFace datasets cache inside the repo by default so the project can run
+    # in offline/sandboxed environments that disallow writes to ~/.cache.
+    datasets_cache_dir = os.environ.get("HF_DATASETS_CACHE") or os.path.join(
+        ROOT_PATH, ".hf_cache", "datasets"
+    )
+    os.makedirs(datasets_cache_dir, exist_ok=True)
     for dataset_attr in data_args.dataset_list:
         logger.info("Loading dataset {}...".format(dataset_attr))
         if dataset_attr.load_from == "hf_hub":
@@ -52,7 +58,13 @@ def get_dataset(data_args: "DataArguments") -> Union["Dataset", "IterableDataset
             checksum(data_files, dataset_attr.dataset_sha1)
         else:
             raise NotImplementedError
-        dataset = load_dataset(data_path, data_files=data_files, split=data_args.split, streaming=data_args.streaming)
+        dataset = load_dataset(
+            data_path,
+            data_files=data_files,
+            split=data_args.split,
+            streaming=data_args.streaming,
+            cache_dir=datasets_cache_dir,
+        )
         if max_samples is not None:
             max_samples_temp = min(len(dataset), max_samples)
             dataset = dataset.select(range(max_samples_temp))

--- a/scripts/run_compare_eval.py
+++ b/scripts/run_compare_eval.py
@@ -1,0 +1,322 @@
+import argparse
+import ast
+import csv
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+BASE_EVAL_DIR = Path("output/model_eval_base")
+RL_EVAL_DIR = Path("output/model_eval_rl")
+
+
+def run_eval(
+    repo_root: Path,
+    model_name: str,
+    dataset: str,
+    template: str,
+    dataset_name: str,
+    trained_agent_path: Optional[str],
+    outdir: Path,
+    n_rows: int,
+) -> None:
+    """Run one evaluation (base or RL) via evaluate_model.py."""
+
+    from subprocess import check_call
+
+    args = [
+        sys.executable,
+        "-m",
+        "sql_rl_gen.generation.evaluate_model",
+        "--model_name_or_path",
+        model_name,
+        "--dataset",
+        dataset,
+        "--template",
+        template,
+        "--outdir",
+        str(outdir),
+        "--dataset_name",
+        dataset_name,
+        "--number_of_rows_to_use",
+        str(n_rows),
+    ]
+    if trained_agent_path is not None:
+        args.extend(["--trained_agent_path", trained_agent_path])
+
+    print("Running:", " ".join(args))
+    check_call(args, cwd=str(repo_root))
+
+
+def load_eval_csv(csv_path: Path) -> List[Dict[str, Any]]:
+    """Load evaluate_model.py's statistics_metrics file into per-sample rows."""
+
+    with csv_path.open(encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows_in_file = list(reader)
+
+    if not rows_in_file:
+        return []
+
+    # Usually the file has 1-2 lines; the last line contains per-sample lists.
+    row = rows_in_file[-1]
+
+    def parse_list(value: str) -> list:
+        try:
+            return ast.literal_eval(value)
+        except Exception:
+            return []
+
+    accuracies = parse_list(row.get("accuracy", "[]"))
+    outputs = parse_list(row.get("output", "[]"))
+    expecteds = parse_list(row.get("expected", "[]"))
+
+    n = min(len(accuracies), len(outputs), len(expecteds))
+
+    per_sample: List[Dict[str, Any]] = []
+    for i in range(n):
+        out_i = outputs[i]
+        # `output` can be a tuple like ("SQL ...",)
+        if isinstance(out_i, tuple) and out_i:
+            out_str = out_i[0]
+        else:
+            out_str = str(out_i)
+
+        per_sample.append(
+            {
+                "accuracy": float(accuracies[i]),
+                "output": out_str,
+                "expected": str(expecteds[i]),
+            }
+        )
+
+    return per_sample
+
+
+def build_comparison_table(base_rows: List[Dict[str, Any]], rl_rows: List[Dict[str, Any]]) -> str:
+    """Align base vs RL by row index and return a Markdown table."""
+
+    lines: List[str] = []
+    lines.append("## Sample-by-sample comparison\n")
+    lines.append("| # | gold SQL (expected) | base SQL (output) | base acc | RL SQL (output) | RL acc |")
+    lines.append("| - | ------------------- | ---------------- | -------- | --------------- | ------ |")
+
+    n = min(len(base_rows), len(rl_rows))
+    for idx in range(n):
+        b = base_rows[idx]
+        r = rl_rows[idx]
+        expected = (b.get("expected") or r.get("expected") or "").replace("|", "\\|")
+        base_out = (b.get("output") or "").replace("|", "\\|")
+        rl_out = (r.get("output") or "").replace("|", "\\|")
+        base_acc = b.get("accuracy")
+        rl_acc = r.get("accuracy")
+        lines.append(
+            f"| {idx + 1} | `{expected}` | `{base_out}` | {base_acc} | `{rl_out}` | {rl_acc} |"
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def _normalize_sql(text: str) -> str:
+    """Coarse normalization to avoid counting pure formatting diffs as changes."""
+
+    s = (text or "").strip()
+    s = re.sub(r"\s+", " ", s)
+    s = s.rstrip(";").strip()
+    return s.lower()
+
+
+def compute_summary(base_rows: List[Dict[str, Any]], rl_rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    n = min(len(base_rows), len(rl_rows))
+    if n == 0:
+        return {
+            "n_samples": 0,
+            "base_acc_mean": 0.0,
+            "rl_acc_mean": 0.0,
+            "diff_count": 0,
+            "changed_sql_count": 0,
+        }
+
+    base_acc_mean = sum(float(base_rows[i].get("accuracy", 0.0) or 0.0) for i in range(n)) / n
+    rl_acc_mean = sum(float(rl_rows[i].get("accuracy", 0.0) or 0.0) for i in range(n)) / n
+    diff_count = sum(
+        1
+        for i in range(n)
+        if float(base_rows[i].get("accuracy", 0.0) or 0.0)
+        != float(rl_rows[i].get("accuracy", 0.0) or 0.0)
+    )
+    changed_sql_count = sum(
+        1
+        for i in range(n)
+        if _normalize_sql(str(base_rows[i].get("output") or ""))
+        != _normalize_sql(str(rl_rows[i].get("output") or ""))
+    )
+
+    return {
+        "n_samples": n,
+        "base_acc_mean": base_acc_mean,
+        "rl_acc_mean": rl_acc_mean,
+        "diff_count": diff_count,
+        "changed_sql_count": changed_sql_count,
+    }
+
+
+def get_git_info(repo_root: Path) -> Dict[str, str]:
+    """Return git branch/commit info (best-effort)."""
+
+    from subprocess import check_output
+
+    def _run(cmd: List[str]) -> Optional[str]:
+        try:
+            return check_output(cmd, cwd=repo_root, text=True).strip()
+        except Exception:
+            return None
+
+    branch = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    commit = _run(["git", "rev-parse", "HEAD"])
+    short_commit = _run(["git", "rev-parse", "--short", "HEAD"])
+    dirty = _run(["git", "status", "--porcelain"])
+    info = {
+        "git_branch": branch,
+        "git_commit": commit,
+        "git_short_commit": short_commit,
+        "git_dirty": ("true" if dirty else "false") if dirty is not None else None,
+    }
+    return {k: v for k, v in info.items() if v is not None}
+
+
+def build_markdown_report(
+    base_rows: List[Dict[str, Any]],
+    rl_rows: List[Dict[str, Any]],
+    run_params: Dict[str, Any],
+    summary: Dict[str, Any],
+) -> str:
+    lines: List[str] = []
+    lines.append("# Base model vs RL model comparison\n")
+
+    lines.append("## Run parameters")
+    for k in [
+        "dataset",
+        "dataset_name",
+        "template",
+        "number_of_rows_to_use",
+        "model_name_or_path",
+        "trained_agent_path",
+        "base_eval_dir",
+        "rl_eval_dir",
+        "git_branch",
+        "git_short_commit",
+        "git_commit",
+        "git_dirty",
+    ]:
+        if k in run_params and run_params[k] is not None:
+            lines.append(f"- {k}: `{run_params[k]}`")
+    lines.append("")
+
+    lines.append("## Summary metrics")
+    lines.append(f"- base_acc_mean: {summary['base_acc_mean']:.6f}")
+    lines.append(f"- rl_acc_mean: {summary['rl_acc_mean']:.6f}")
+    lines.append(f"- diff_count: {summary['diff_count']}")
+    lines.append(f"- changed_sql_count: {summary['changed_sql_count']}")
+    lines.append("")
+
+    lines.append(build_comparison_table(base_rows, rl_rows))
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run base and RL evaluation and generate a Markdown comparison report"
+    )
+    parser.add_argument("--model_name_or_path", type=str, required=True)
+    parser.add_argument("--dataset", type=str, default="example_text2sql_spider_dev")
+    parser.add_argument("--dataset_name", type=str, default="spider")
+    parser.add_argument("--template", type=str, default="llama3")
+    parser.add_argument("--trained_agent_path", type=str, required=True)
+    parser.add_argument("--number_of_rows_to_use", type=int, default=200)
+    parser.add_argument("--out_md", type=str, default="output/compare_base_vs_rl.md")
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+
+    print(
+        "[compare-eval] dataset={} dataset_name={} n_rows={}".format(
+            args.dataset, args.dataset_name, args.number_of_rows_to_use
+        )
+    )
+    if args.dataset.startswith("example_"):
+        print(
+            "[compare-eval] NOTE: You are evaluating an example dataset. "
+            "If base vs RL looks identical, consider using a harder/larger eval set."
+        )
+
+    base_eval_dir = root / BASE_EVAL_DIR
+    base_eval_dir.mkdir(parents=True, exist_ok=True)
+    run_eval(
+        repo_root=root,
+        model_name=args.model_name_or_path,
+        dataset=args.dataset,
+        template=args.template,
+        dataset_name=args.dataset_name,
+        trained_agent_path=None,
+        outdir=base_eval_dir,
+        n_rows=args.number_of_rows_to_use,
+    )
+
+    rl_eval_dir = root / RL_EVAL_DIR
+    rl_eval_dir.mkdir(parents=True, exist_ok=True)
+    run_eval(
+        repo_root=root,
+        model_name=args.model_name_or_path,
+        dataset=args.dataset,
+        template=args.template,
+        dataset_name=args.dataset_name,
+        trained_agent_path=args.trained_agent_path,
+        outdir=rl_eval_dir,
+        n_rows=args.number_of_rows_to_use,
+    )
+
+    base_csv = base_eval_dir / "statistics_metrics"
+    rl_csv = rl_eval_dir / "statistics_metrics"
+
+    if not base_csv.exists():
+        raise FileNotFoundError("Base evaluation result not found: {}".format(base_csv))
+    if not rl_csv.exists():
+        raise FileNotFoundError("RL evaluation result not found: {}".format(rl_csv))
+
+    base_rows = load_eval_csv(base_csv)
+    rl_rows = load_eval_csv(rl_csv)
+
+    summary = compute_summary(base_rows, rl_rows)
+    print(
+        "[compare-eval] summary:",
+        "base_acc_mean={:.6f}".format(summary["base_acc_mean"]),
+        "rl_acc_mean={:.6f}".format(summary["rl_acc_mean"]),
+        "diff_count={}".format(summary["diff_count"]),
+        "changed_sql_count={}".format(summary["changed_sql_count"]),
+        "n_samples={}".format(summary["n_samples"]),
+    )
+
+    run_params: Dict[str, Any] = {
+        "dataset": args.dataset,
+        "dataset_name": args.dataset_name,
+        "template": args.template,
+        "number_of_rows_to_use": args.number_of_rows_to_use,
+        "model_name_or_path": args.model_name_or_path,
+        "trained_agent_path": args.trained_agent_path,
+        "base_eval_dir": str(base_eval_dir.resolve()),
+        "rl_eval_dir": str(rl_eval_dir.resolve()),
+    }
+    run_params.update(get_git_info(root))
+
+    md = build_markdown_report(base_rows, rl_rows, run_params, summary)
+
+    out_md_path = root / args.out_md
+    out_md_path.parent.mkdir(parents=True, exist_ok=True)
+    out_md_path.write_text(md, encoding="utf-8")
+    print("Markdown report generated:", out_md_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_compare_eval.sh
+++ b/scripts/run_compare_eval.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Please activate your Python environment before running (e.g. `conda activate sql-rl-gen`).
+
+MODEL_NAME_OR_PATH="${MODEL_NAME_OR_PATH:-juierror/flan-t5-text2sql-with-schema-v2}"
+TRAINED_AGENT_PATH="${TRAINED_AGENT_PATH:-./output/model_spider_train/best}"
+DATASET="${DATASET:-example_text2sql_spider_dev}"
+DATASET_NAME="${DATASET_NAME:-spider}"
+TEMPLATE="${TEMPLATE:-llama3}"
+# Default to >=200 rows to avoid tiny/easy eval sets hiding differences
+N_ROWS="${N_ROWS:-200}"
+OUT_MD="${OUT_MD:-output/compare_spider_base_vs_rl.md}"
+
+echo "[run_compare_eval.sh] dataset=${DATASET} dataset_name=${DATASET_NAME} n_rows=${N_ROWS}"
+echo "[run_compare_eval.sh] model_name_or_path=${MODEL_NAME_OR_PATH}"
+echo "[run_compare_eval.sh] trained_agent_path=${TRAINED_AGENT_PATH}"
+echo "[run_compare_eval.sh] out_md=${OUT_MD}"
+
+python scripts/run_compare_eval.py \
+  --model_name_or_path "${MODEL_NAME_OR_PATH}" \
+  --trained_agent_path "${TRAINED_AGENT_PATH}" \
+  --dataset "${DATASET}" \
+  --dataset_name "${DATASET_NAME}" \
+  --template "${TEMPLATE}" \
+  --number_of_rows_to_use "${N_ROWS}" \
+  --out_md "${OUT_MD}"

--- a/scripts/setup_spider_data.py
+++ b/scripts/setup_spider_data.py
@@ -1,0 +1,99 @@
+import argparse
+import os
+import sys
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+
+def download(url: str, dst_path: Path) -> None:
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def reporthook(block_num: int, block_size: int, total_size: int) -> None:
+        if total_size <= 0:
+            return
+        downloaded = block_num * block_size
+        pct = min(100.0, downloaded * 100.0 / total_size)
+        sys.stdout.write("\rDownloading: {:.1f}%".format(pct))
+        sys.stdout.flush()
+
+    print("Downloading:", url)
+    urllib.request.urlretrieve(url, str(dst_path), reporthook=reporthook)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def safe_extract_zip(zip_path: Path, extract_dir: Path, force: bool) -> None:
+    extract_dir.mkdir(parents=True, exist_ok=True)
+    extract_dir_resolved = extract_dir.resolve()
+    with zipfile.ZipFile(str(zip_path)) as zf:
+        members = zf.infolist()
+        for m in members:
+            target = extract_dir / m.filename
+            target_resolved = target.resolve()
+            common = os.path.commonpath([str(extract_dir_resolved), str(target_resolved)])
+            if common != str(extract_dir_resolved):
+                raise RuntimeError("Unsafe path in zip: {}".format(m.filename))
+        if force:
+            zf.extractall(str(extract_dir))
+        else:
+            for m in members:
+                target = extract_dir / m.filename
+                if target.exists():
+                    continue
+                zf.extract(m, str(extract_dir))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Download (optional) and extract Spider dataset zip into data_preprocess/data/"
+    )
+    parser.add_argument(
+        "--zip-path",
+        type=str,
+        default="data_preprocess/data/spider.zip",
+        help="Path to spider.zip",
+    )
+    parser.add_argument(
+        "--extract-dir",
+        type=str,
+        default="data_preprocess/data",
+        help="Directory to extract into (should contain spider/ after extraction)",
+    )
+    parser.add_argument(
+        "--url",
+        type=str,
+        default=None,
+        help="Optional URL to download spider.zip if it does not exist locally",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing extracted files",
+    )
+    args = parser.parse_args()
+
+    zip_path = Path(args.zip_path)
+    extract_dir = Path(args.extract_dir)
+    url: Optional[str] = args.url
+
+    if not zip_path.exists():
+        if url is None:
+            print("ERROR: {} not found.".format(zip_path))
+            print("Please download the dataset bundle and place spider.zip at that path, or pass --url.")
+            sys.exit(2)
+        download(url, zip_path)
+
+    print("Extracting:", zip_path, "->", extract_dir)
+    safe_extract_zip(zip_path, extract_dir, force=args.force)
+
+    expected_db_dir = extract_dir / "spider" / "database"
+    if not expected_db_dir.exists():
+        print("WARNING: Expected directory not found:", expected_db_dir)
+    else:
+        print("OK: Spider DB directory:", expected_db_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/sql_rl_gen/generation/envs/sql_generation_environment_obs.py
+++ b/sql_rl_gen/generation/envs/sql_generation_environment_obs.py
@@ -1,6 +1,7 @@
 from typing import Tuple, Dict
 from textrl import TextRLEnv
 from sql_rl_gen.generation.envs.utils import sql_query_execution_feedback_on_dataset, save_dict_csv
+from sql_rl_gen.generation.envs.sql_generation_environment import compute_reward as compute_reward_base
 
 KEY_WORDS = ["SELECT", "FROM", "WHERE", "JOIN", "INNER", "OUTER", "LEFT", "RIGHT", "AS", "ON", "EXCEPT", "DISTINCT", "GROUP BY", "ORDER BY", "NOT", "ASC", "DESC", "LIMIT", "LIKE", "COUNT", "SUM", "AVG", "MIN", "MAX"]
 
@@ -60,4 +61,6 @@ class SQLRLEnv(TextRLEnv):
         return 0.0
 
     # Skeleton of the reward function
-    def compute_reward(self, input_item, predicted_text) -> Tuple[float, Dict]
+    def compute_reward(self, input_item, predicted_text) -> Tuple[float, Dict]:
+        # Deprecated/legacy env: reuse the main environment reward implementation.
+        return compute_reward_base(self, input_item, predicted_text)

--- a/sql_rl_gen/generation/envs/utils.py
+++ b/sql_rl_gen/generation/envs/utils.py
@@ -9,12 +9,13 @@ from data_preprocess.sql_utils import execute_query
 from sql_rl_gen.feedback_metrics import calculate_all_feedback_metrics
 
 def find_device() -> torch.device:
-    if torch.backends.mps.is_available():
-        return torch.device('mps')
-    elif torch.backends.cudnn.is_available():
-        return torch.device('cuda')
-    else:
-        return torch.device('cpu')
+    # IMPORTANT: `torch.backends.cudnn.is_available()` can be True even when there are
+    # 0 CUDA devices (CPU-only runtime). Use `torch.cuda.is_available()` instead.
+    if getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+        return torch.device("mps")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
 
 def replace_columns(predicted_query, tables):
     for i in range(len(tables[0])):

--- a/sql_rl_gen/generation/evaluate_model.py
+++ b/sql_rl_gen/generation/evaluate_model.py
@@ -3,8 +3,10 @@ import os.path
 import sys
 from os import listdir
 from statistics import mode
+
 import torch
 from transformers import HfArgumentParser, AutoTokenizer, AutoModelForSeq2SeqLM
+
 from configs.config import BIRD_DATABASES_DEV_PATH, SPIDER_DATABASES_PATH, WIKISQL_PATH
 from configs.data_args import DataArguments, DatasetName
 from configs.rl_args import EvaluateArguments, EvaluationMethod
@@ -18,6 +20,25 @@ from sql_rl_gen.generation.rllib.custom_trainer import train_evaulate_agent
 os.environ["TOKENIZERS_PARALLELISM"] = "true"
 device = find_device()
 
+def _resolve_and_validate_trained_agent_path(trained_agent_path: str) -> str:
+    """Resolve `trained_agent_path` and fail fast if it does not exist.
+
+    This is intentionally strict: when users pass `--trained_agent_path`,
+    we must not silently fall back to base-model evaluation.
+    """
+
+    if trained_agent_path is None or not str(trained_agent_path).strip():
+        raise ValueError(
+            "`--trained_agent_path` was provided but is empty/None; refusing to fall back to base model."
+        )
+
+    resolved = os.path.expanduser(str(trained_agent_path))
+    if not os.path.exists(resolved):
+        raise FileNotFoundError(
+            f"RL checkpoint path not found: {trained_agent_path!r} (resolved: {resolved!r})."
+        )
+    return resolved
+
 def prediction_feedback(statistics, data_list_to_pass, dataset_path, observation, result, columns_names_mismatch):
     feedback = sql_query_execution_feedback_on_dataset(data_list_to_pass, dataset_path, observation['input'], result, columns_names_mismatch)
     for k, v in feedback.items():
@@ -25,7 +46,7 @@ def prediction_feedback(statistics, data_list_to_pass, dataset_path, observation
             statistics[k].append(v)
         else:
             statistics[k] = [v]
-        logging.info(f"Appending to {k} value: {v}")
+        logging.debug(f"Appending to {k} value: {v}")
     if device == torch.device("cuda"):
         torch.cuda.empty_cache()
     elif device == torch.device("mps"):
@@ -77,19 +98,49 @@ def prepare_for_evaluate(eval_args: EvaluateArguments, data_args: DataArguments)
     return dataset_path, observation_list, data_list_to_pass, columns_names_mismatch, model, tokenizer
 
 def evaluate_models(eval_args: EvaluateArguments, data_args: DataArguments):
-    dataset_path, observation_list, data_list_to_pass, columns_names_mismatch, model, tokenizer = prepare_for_evaluate(eval_args, data_args)
-    model.eval()
     logging.basicConfig(level=logging.INFO, stream=sys.stdout, format='')
     logger = logging.getLogger("Test")
-    if eval_args.trained_agent_path:
+
+    trained_agent_path = eval_args.trained_agent_path
+    rl_checkpoint_loaded = False
+    if trained_agent_path is not None:
+        trained_agent_path = _resolve_and_validate_trained_agent_path(trained_agent_path)
+
+    logger.info(
+        "[eval] model=%s dataset=%s dataset_name=%s template=%s n_rows=%s outdir=%s",
+        eval_args.model_name_or_path,
+        data_args.dataset,
+        data_args.dataset_name,
+        data_args.template,
+        eval_args.number_of_rows_to_use,
+        eval_args.outdir,
+    )
+    logger.info(
+        "[eval] rl_checkpoint_requested=%s path=%s",
+        trained_agent_path is not None,
+        trained_agent_path,
+    )
+
+    dataset_path, observation_list, data_list_to_pass, columns_names_mismatch, model, tokenizer = prepare_for_evaluate(eval_args, data_args)
+    model.eval()
+
+    actor = None
+    if trained_agent_path is not None:
         env = SQLRLEnv(model, tokenizer, data_list_to_pass, dataset_path, eval_args.outdir, logger, "evaluation", columns_names_mismatch=columns_names_mismatch,
                        observation_input=observation_list, compare_sample=1)
         actor = CustomActor(env, model, tokenizer, temperature=eval_args.temperature, top_k=eval_args.top_k, top_p=eval_args.top_p)
         agent = actor.agent_ppo(update_interval=eval_args.update_interval, minibatch_size=eval_args.minibatch_size, epochs=eval_args.epochs, lr=eval_args.lr)
-        agent.load(eval_args.trained_agent_path)
+        try:
+            agent.load(trained_agent_path)
+        except Exception:
+            logger.exception("[eval] rl_checkpoint_loaded=False path=%s", trained_agent_path)
+            raise
+        rl_checkpoint_loaded = True
+        logger.info("[eval] rl_checkpoint_loaded=True path=%s", trained_agent_path)
+
     statistics = {}
     for observation in observation_list:
-        if eval_args.trained_agent_path:
+        if actor is not None:
             result = actor.predict(observation)[0][:-4]
         else:
             input_ids = tokenizer(observation['input'], return_tensors="pt", max_length=1024).input_ids
@@ -103,6 +154,12 @@ def evaluate_models(eval_args: EvaluateArguments, data_args: DataArguments):
     feedback = construct_file(statistics)
     save_dict_csv(feedback, eval_args.outdir, "feedback_metrics")
     save_dict_csv(statistics, eval_args.outdir, "statistics_metrics")
+    logger.info(
+        "[eval] done rl_checkpoint_loaded=%s path=%s n_samples=%d",
+        rl_checkpoint_loaded,
+        trained_agent_path,
+        len(observation_list),
+    )
     return feedback, statistics
 
 def cross_validation_evaluate(eval_args: EvaluateArguments, data_args: DataArguments):

--- a/sql_rl_gen/generation/rllib/custom_actor.py
+++ b/sql_rl_gen/generation/rllib/custom_actor.py
@@ -1,4 +1,6 @@
-from textrl.actor import TextRLActor, TextPPO
+import pfrl
+import torch
+from textrl.actor import TextRLActor, TextPPO, SoftmaxCategoricalHead
 from pfrl.utils.batch_states import batch_states
 from sql_rl_gen.generation.envs.utils import find_device
 
@@ -8,6 +10,63 @@ class CustomActor(TextRLActor):
     def __init__(self, env, model, tokenizer, optimizer='sgd', gpu_id=0, unfreeze_layer_from_past=0, act_deterministically=True, temperature=1.0, top_k=0, top_p=1.0):
         super().__init__(env, model, tokenizer, optimizer, gpu_id, unfreeze_layer_from_past, act_deterministically, temperature, top_k, top_p)
         self.device = device_to_use
+
+    def agent_ppo(self, update_interval=10, minibatch_size=3000, epochs=20, lr=3e-6):
+        """Device-aware PPO builder.
+
+        Upstream textrl's `TextRLActor.agent_ppo()` hard-calls `.cuda()`, which breaks
+        CPU-only/offline environments. This override keeps the same architecture but
+        respects the selected device.
+        """
+
+        policy = torch.nn.Sequential(
+            self.middle_model,
+            self.remaining_model,
+            self.converter,
+            SoftmaxCategoricalHead(
+                self.env,
+                temperature=self.temperature,
+                top_k=self.top_k,
+                top_p=self.top_p,
+            ),
+        )
+        vf = torch.nn.Sequential(
+            torch.nn.Linear(self.obs_size, self.obs_size // 2),
+            torch.nn.Linear(self.obs_size // 2, self.obs_size // 4),
+            torch.nn.Linear(self.obs_size // 4, 1),
+        )
+        model = pfrl.nn.Branched(policy, vf)
+
+        if isinstance(self.optimizer, str):
+            if self.optimizer.lower() == "adamw":
+                opt = torch.optim.AdamW(model.parameters(), lr=lr)
+            else:
+                opt = torch.optim.SGD(model.parameters(), lr=lr)
+        else:
+            opt = self.optimizer
+
+        device = self.device
+        if device.type not in ("cpu", "cuda"):
+            device = torch.device("cpu")
+        model = model.to(device)
+
+        agent = TextPPO(
+            model,
+            opt,
+            gpu=(self.gpu_id if device.type == "cuda" else None),
+            update_interval=update_interval,
+            minibatch_size=minibatch_size,
+            epochs=epochs,
+            clip_eps_vf=None,
+            entropy_coef=0,
+            gamma=0.95,  # https://arxiv.org/abs/2210.01241
+            lambd=1,
+            max_grad_norm=1.0,
+            standardize_advantages=True,
+            act_deterministically=self.act_deterministically,
+        )
+        self.agent = agent
+        return agent
 
 class CustomTextPPO(TextPPO):
     def __init__(self, model, optimizer, device, obs_normalizer=None, gamma=0.99, lambd=0.95, phi=lambda x: x, value_func_coef=1.0,

--- a/sql_rl_gen/generation/rllib/custom_trainer.py
+++ b/sql_rl_gen/generation/rllib/custom_trainer.py
@@ -1,83 +1,229 @@
 import logging
 import os
+import time
+
+import torch
 from pfrl.experiments.evaluator import Evaluator
 from textrl import save_agent
+from tqdm import tqdm
+
 from sql_rl_gen.generation.envs.utils import save_dict_csv
 
-def train_evaulate_agent(agent, env, steps, eval_n_steps, eval_n_episodes, eval_interval, outdir, checkpoint_freq=None, train_max_episode_len=None, step_offset=0, eval_max_episode_len=None,
-                         eval_env=None, successful_score=None, step_hooks=(), evaluation_hooks=(), save_best_so_far_agent=True, use_tensorboard=False, eval_during_episode=False, logger=None):
+try:
+    # tensorboardX is optional; training should not crash if it's unavailable or broken in the runtime.
+    from tensorboardX import SummaryWriter
+except Exception:  # pragma: no cover
+    SummaryWriter = None
+
+
+def train_evaulate_agent(
+    agent,
+    env,
+    steps,
+    eval_n_steps,
+    eval_n_episodes,
+    eval_interval,
+    outdir,
+    checkpoint_freq=None,
+    train_max_episode_len=None,
+    step_offset=0,
+    eval_max_episode_len=None,
+    eval_env=None,
+    successful_score=None,
+    step_hooks=(),
+    evaluation_hooks=(),
+    save_best_so_far_agent=True,
+    use_tensorboard=False,
+    eval_during_episode=False,
+    logger=None,
+    log_interval=50,
+    use_tqdm=True,
+    print_every_step=False,
+):
     for hook in evaluation_hooks:
         if not hook.support_train_agent:
             raise ValueError("{} does not support train_agent_with_evaluation().".format(hook))
     os.makedirs(outdir, exist_ok=True)
     if eval_env is None:
-        assert not eval_during_episode, ("To run evaluation during training episodes, you need to specify `eval_env` that is independent from `env`.")
+        assert not eval_during_episode, (
+            "To run evaluation during training episodes, you need to specify `eval_env` that is independent from `env`."
+        )
         eval_env = env
     if eval_max_episode_len is None:
         eval_max_episode_len = train_max_episode_len
-    evaluator = Evaluator(agent=agent, n_steps=eval_n_steps, n_episodes=eval_n_episodes, eval_interval=eval_interval, outdir=outdir, max_episode_len=eval_max_episode_len, env=eval_env,
-                          step_offset=step_offset, evaluation_hooks=evaluation_hooks, save_best_so_far_agent=save_best_so_far_agent, use_tensorboard=use_tensorboard, logger=logger)
-    eval_stats_history = train_agent(agent, env, steps, outdir, checkpoint_freq=checkpoint_freq, max_episode_len=train_max_episode_len, step_offset=step_offset, evaluator=evaluator,
-                                     successful_score=successful_score, step_hooks=step_hooks, eval_during_episode=eval_during_episode, logger=logger)
+    evaluator = Evaluator(
+        agent=agent,
+        n_steps=eval_n_steps,
+        n_episodes=eval_n_episodes,
+        eval_interval=eval_interval,
+        outdir=outdir,
+        max_episode_len=eval_max_episode_len,
+        env=eval_env,
+        step_offset=step_offset,
+        evaluation_hooks=evaluation_hooks,
+        save_best_so_far_agent=save_best_so_far_agent,
+        use_tensorboard=use_tensorboard,
+        logger=logger,
+    )
+    eval_stats_history = train_agent(
+        agent,
+        env,
+        steps,
+        outdir,
+        checkpoint_freq=checkpoint_freq,
+        max_episode_len=train_max_episode_len,
+        step_offset=step_offset,
+        evaluator=evaluator,
+        successful_score=successful_score,
+        step_hooks=step_hooks,
+        eval_during_episode=eval_during_episode,
+        logger=logger,
+        log_interval=log_interval,
+        use_tqdm=use_tqdm,
+        print_every_step=print_every_step,
+    )
     return agent, eval_stats_history
 
-def train_agent(agent, env, steps, outdir, checkpoint_freq=None, max_episode_len=None, step_offset=0, evaluator=None, successful_score=None, step_hooks=(),
-                eval_during_episode=False, logger=None, max_tokens=250):
+
+def train_agent(
+    agent,
+    env,
+    steps,
+    outdir,
+    checkpoint_freq=None,
+    max_episode_len=None,
+    step_offset=0,
+    evaluator=None,
+    successful_score=None,
+    step_hooks=(),
+    eval_during_episode=False,
+    logger=None,
+    max_tokens=250,  # kept for backward compatibility
+    log_interval=50,
+    use_tqdm=True,
+    print_every_step=False,
+):
     logger = logger or logging.getLogger(__name__)
-    episode_r = 0
+    episode_r = 0.0
     episode_idx = 0
+
     obs = env.reset()
+
+    writer = None
+    if SummaryWriter is not None:
+        tb_logdir = os.path.join(outdir, "tb")
+        try:
+            writer = SummaryWriter(log_dir=tb_logdir)
+        except Exception as e:
+            logger.warning("TensorBoard logging disabled (SummaryWriter init failed): %s", e)
+            writer = None
+            try:
+                if os.path.isdir(tb_logdir) and not os.listdir(tb_logdir):
+                    os.rmdir(tb_logdir)
+            except Exception:
+                pass
+
     t = step_offset
     if hasattr(agent, "t"):
         agent.t = step_offset
-    eval_stats_history = []  # List of evaluation episode stats dict
+
+    eval_stats_history = []
     episode_len = 0
-    tokens = 0
+
+    start_time = time.time()
+    last_log_time = start_time
+    last_logged_step = step_offset
+    moving_reward_sum = 0.0
+    moving_reward_count = 0
+
+    pbar = tqdm(
+        total=steps,
+        initial=step_offset,
+        disable=not use_tqdm,
+        dynamic_ncols=True,
+        desc="Training",
+        mininterval=0.5,
+    )
+
     try:
         while t < steps:
             action = agent.act(obs)
             obs, r, done, info = env.step(action)
-            flag = True # Repeat the action if the reward is not 10.0
-            attempts = 0
-            max_attempts = 10  # Maximum number of attempts to repeat the action
-            while flag:
-                if done:
-                    tokens = 0
-                    reset = episode_len == max_episode_len or info.get("needs_reset", False)
-                    agent.observe(obs, r, done, reset)
-                    if r != 10.0 and attempts < max_attempts:
-                        input = env.input_item
-                        obs = env.reset(input)
-                        action = agent.act(obs)
-                        obs, r, done, info = env.step(action)
-                        attempts += 1
-                    else:
-                        flag = False
-                elif tokens >= max_tokens: # Penalise strictly if model generates a lot of stupid stuff
-                    logger.info("Generated more tokens then allowed")
-                    reset = episode_len == max_episode_len or info.get("needs_reset", False)
-                    agent.observe(obs, -1000, done, reset)
-                    obs = env.reset(env.input_item)
-                    tokens = 0
-                    action = agent.act(obs)
-                    obs, r, done, info = env.step(action)
-                    attempts += 1
-                else:
-                    action = agent.act(obs)  # Let the agent act again based on the new observation
-                    obs, r, done, info = env.step(action)
-                    tokens += 1
+
+            # NOTE: This environment is token-level (one token per step). The previous
+            # implementation attempted to resample until a "perfect" reward, which biases
+            # the training distribution and can lead to infinite retries; we strictly
+            # advance by environment steps now.
             t += 1
-            episode_r += r
+            if use_tqdm:
+                pbar.update(1)
+
+            step_r = sum(r) if isinstance(r, (list, tuple)) else float(r)
+            episode_r += step_r
             episode_len += 1
+
+            reset = episode_len == max_episode_len or info.get("needs_reset", False)
+            agent.observe(obs, r, done, reset)
+
             for hook in step_hooks:
                 hook(env, agent, t)
+
             episode_end = done or reset or t == steps
+
+            if (t - last_logged_step) >= log_interval:
+                now = time.time()
+                elapsed = now - start_time
+                window_elapsed = now - last_log_time if now > last_log_time else 0.0
+                steps_per_sec_window = (
+                    (t - last_logged_step) / window_elapsed if window_elapsed > 0 else 0.0
+                )
+                overall_steps_per_sec = (t - step_offset) / elapsed if elapsed > 0 else 0.0
+                percent = 100.0 * (t / float(steps))
+                gpu_mem = "NA"
+                if torch.cuda.is_available():
+                    alloc = torch.cuda.memory_allocated() / 1024**2
+                    reserved = torch.cuda.memory_reserved() / 1024**2
+                    max_alloc = torch.cuda.max_memory_allocated() / 1024**2
+                    gpu_mem = (
+                        f"alloc={alloc:.1f}MB reserved={reserved:.1f}MB max_alloc={max_alloc:.1f}MB"
+                    )
+                avg_reward_so_far = (
+                    (moving_reward_sum / moving_reward_count) if moving_reward_count > 0 else 0.0
+                )
+                logger.info(
+                    "[progress] step %d/%d (%.1f%%) | eps %d | avgR %.3f | step/s(cur)=%.2f step/s(avg)=%.2f | elapsed %.1fs | gpu %s",
+                    t,
+                    steps,
+                    percent,
+                    episode_idx,
+                    avg_reward_so_far,
+                    steps_per_sec_window,
+                    overall_steps_per_sec,
+                    elapsed,
+                    gpu_mem,
+                )
+                last_logged_step = t
+                last_log_time = now
+
+            if print_every_step:
+                logger.info("[step] %d/%d r=%.4f eps=%d len=%d", t, steps, step_r, episode_idx, episode_len)
+
             if episode_end:
-                logger.info("outdir:%s step:%s episode:%s R:%s",outdir, t, episode_idx, episode_r)
+                logger.info("outdir:%s step:%s episode:%s R:%s", outdir, t, episode_idx, episode_r)
+                if writer is not None:
+                    writer.add_scalar("train/episode_reward", episode_r, t)
+
                 stats = agent.get_statistics()
                 save_dict_csv(dict(stats), outdir, "scores")
                 logger.info("statistics:%s", stats)
+
+                if use_tqdm:
+                    pbar.set_postfix({"episode": episode_idx, "R": f"{episode_r:.3f}"})
+
+                moving_reward_sum += episode_r
+                moving_reward_count += 1
                 episode_idx += 1
+
             if evaluator is not None and (episode_end or eval_during_episode):
                 eval_score = evaluator.evaluate_if_necessary(t=t, episodes=episode_idx)
                 if eval_score is not None:
@@ -86,16 +232,25 @@ def train_agent(agent, env, steps, outdir, checkpoint_freq=None, max_episode_len
                     eval_stats_history.append(eval_stats)
                 if successful_score is not None and evaluator.max_score >= successful_score:
                     break
+
             if episode_end:
                 if t == steps:
                     break
-                episode_r = 0 # Start a new episode
+                episode_r = 0.0
                 episode_len = 0
                 obs = env.reset()
+
             if checkpoint_freq and t % checkpoint_freq == 0:
                 save_agent(agent, t, outdir, logger, suffix="_checkpoint")
+
     except (Exception, KeyboardInterrupt):
         save_agent(agent, t, outdir, logger, suffix="_except")
         raise
+    finally:
+        if writer is not None:
+            writer.close()
+        if use_tqdm:
+            pbar.close()
+
     save_agent(agent, t, outdir, logger, suffix="_finish")
     return eval_stats_history


### PR DESCRIPTION
### Why
- Make RL evaluation trustworthy (no silent base-model fallback when a wrong checkpoint path is passed).
- Make offline/sandboxed runs easier (repo-local HF datasets cache; robust project/data/output paths).
- Make training loop stable (remove reward-based resampling that can bias training and hang).

### What changed
- Evaluation: strict `--trained_agent_path` validation + explicit logs for “checkpoint requested/loaded” (`sql_rl_gen/generation/evaluate_model.py`).
- Compare-eval helper: generate a Markdown report with run parameters and summary metrics (`base_acc_mean`, `rl_acc_mean`, `diff_count`, `changed_sql_count`) (`scripts/run_compare_eval.py`, `scripts/run_compare_eval.sh`).
- Training loop: remove the “retry until perfect reward” loop; per-step `observe`; clearer progress logging; TensorBoard optional (`sql_rl_gen/generation/rllib/custom_trainer.py`).
- CPU/offline robustness: avoid unconditional `.cuda()`; device detection uses `torch.cuda.is_available()` (`sql_rl_gen/generation/rllib/custom_actor.py`, `sql_rl_gen/generation/envs/utils.py`).
- Data helper: safe extraction script for an existing `spider.zip` (`scripts/setup_spider_data.py`).
- Add `.gitignore` and README notes to keep dataset archives/outputs/caches out of git.

### Data
Official dataset bundle: https://ibm.box.com/v/sql-rl-gen-data  
This PR does not add dataset archives to git. Datasets should be extracted under `data_preprocess/data/`.

### How to test
```bash
conda activate sql-rl-gen
python -m compileall -q sql_rl_gen/generation scripts/*.py configs/*.py data_preprocess/*.py
python data_preprocess/spider_sql_data_process.py --dataset spider

python sql_rl_gen/generation/sql_generation.py \
  --model_name_or_path ./local_models/flan-t5-text2sql-with-schema-v2-unpacked \
  --dataset example_text2sql_spider_train \
  --template llama3 --dataset_name spider \
  --outdir ./output/model_spider_train_smoke_20_pr \
  --steps_n 20 --update_interval 10 --epochs 1 --eval_n_episodes 1

python scripts/run_compare_eval.py \
  --model_name_or_path ./local_models/flan-t5-text2sql-with-schema-v2-unpacked \
  --trained_agent_path ./output/model_spider_train_smoke_20_pr/best \
  --dataset example_text2sql_spider_dev --dataset_name spider --template llama3 \
  --number_of_rows_to_use 200 \
  --out_md output/compare_spider_base_vs_rl_200_pr.md
